### PR TITLE
Include rudimentary ordering of content by timestamp + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ representing that level of the taxonomy.
 
 The taxonomy data represented in these pages is cached locally in
 [app/data/taxonomy-data.json](app/data/taxonomy-data.json). This saves us from
-having to make multiple calls to the publishing API to render a single page in
-the prototype.
+having to make multiple network calls to render a single page in the prototype.
 
 The Ruby script
 [bin/generate_prototype_data.rb](bin/generate_prototype_data.rb) regenerates
 the taxonomy data file. It uses the production API endpoints for the
-publishing-api, content-store and rummager to fetch changes. The taxons that
-are imported by this script are hard-coded in
+publishing-api, content-store and rummager to fetch various bits of data about
+each taxon. The taxons that are imported by this script are hard-coded in
 [app/data/taxon-slugs.yaml](app/data/taxon-slugs.yaml).
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -1,39 +1,48 @@
-# GOV.UK Prototype kit
+# Navigation Prototype
 
-## News
+This app serves up prototype navigation flows for the work-in-progress GOV.UK
+taxonomy.
 
-**Upgrading from version 1 to 2:** the latest version of the kit (2.0.0 and later) is not compatible with previous versions. If you update your old prototypes you'll need to [convert them as well](https://github.com/alphagov/govuk_prototype_kit/blob/master/docs/updating-the-kit.md).
+## Screenshots
 
-## About the prototype kit
+None yet - the navigation screens are in an ongoing state of flux so any
+screenshots included here would very quickly be out of date.
 
-The prototype kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research.
+## Nomenclature
 
-Read the [project principles](docs/principles.md).
+- **taxon**: a single node within the taxonomy.
 
-> You must protect user privacy at all times, even when using prototypes. Prototypes made with the kit look like GOV.UK, but do not have the same security provisions. Always make sure you are handling user data appropriately. 
+## Technical documentation
 
-## Installation instructions
+This is a node app built using the
+[govuk_prototype_kit](https://github.com/alphagov/govuk_prototype_kit). It
+serves up several endpoints, each containing a specific design variation. These
+endpoints accept a taxon slug as a parameter and subsequently display a page
+representing that level of the taxonomy.
 
-- [Installation guide for new users (non technical)](docs/install/introduction.md)
-- [Installation guide for developers (technical)](docs/developer-install-instructions.md)
+The taxonomy data represented in these pages is cached locally in
+[app/data/taxonomy-data.json](app/data/taxonomy-data.json). This saves us from
+having to make multiple calls to the publishing API to render a single page in
+the prototype. The Ruby script
+[bin/generate_prototype_data.rb](bin/generate_prototype_data.rb) regenerates
+the taxonomy data file, picking up the latest changes from the publishing API.
+The taxons that are imported by this script are hard-coded in
+[app/data/taxon-slugs.yaml](app/data/taxon-slugs.yaml).
 
-## Guides
+### Dependencies
 
-1. [Setting up git](docs/guides/setting-up-git.md)
-1. [Publishing on the web (Heroku)](docs/guides/publishing-on-heroku.md)
+See package.json.
 
-## Other documentation
+### Running the application
 
-- [Prototype kit principles](docs/principles.md)
-- [Making pages](docs/making-pages.md)
-- [Writing CSS](docs/writing-css.md)
-- [Updating the kit to the latest version](docs/updating-the-kit.md)
-- [Tips and tricks](docs/tips-and-tricks.md)
-- [Creating routes (server-side programming)](docs/creating-routes.md)
+Run `npm install` if running for the first time or if you've added anything to
+package.json.
 
-## Community
+`node start`
 
-We have two Slack channels for the Prototype kit. You'll need a government email address to join them.
+Open the app at http://localhost:3000/
 
-* [Slack channel for users of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
-* [Slack channel for developers of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
+## Licence
+
+[MIT License](LICENCE)
+

--- a/README.md
+++ b/README.md
@@ -23,10 +23,13 @@ representing that level of the taxonomy.
 The taxonomy data represented in these pages is cached locally in
 [app/data/taxonomy-data.json](app/data/taxonomy-data.json). This saves us from
 having to make multiple calls to the publishing API to render a single page in
-the prototype. The Ruby script
+the prototype.
+
+The Ruby script
 [bin/generate_prototype_data.rb](bin/generate_prototype_data.rb) regenerates
-the taxonomy data file, picking up the latest changes from the publishing API.
-The taxons that are imported by this script are hard-coded in
+the taxonomy data file. It uses the production API endpoints for the
+publishing-api, content-store and rummager to fetch changes. The taxons that
+are imported by this script are hard-coded in
 [app/data/taxon-slugs.yaml](app/data/taxon-slugs.yaml).
 
 ### Dependencies

--- a/app/helpers/taxonomy-data-helpers.js
+++ b/app/helpers/taxonomy-data-helpers.js
@@ -6,9 +6,12 @@ var fetchCurrentTaxonTitle = function (taxonSlug) {
   return taxonomyData[taxonSlug].title;
 }
 
-// Retrieve content items tagged to a specific taxon.
+// Retrieve content items tagged to a specific taxon, ordered public_updated_at
+// ascending.
 var fetchTaggedItems = function (taxonSlug) {
-  return taxonomyData[taxonSlug]["tagged_content"];
+  return taxonomyData[taxonSlug]["tagged_content"].sort(function(a, b) {
+    return new Date(a.public_updated_at) - new Date(b.public_updated_at);
+  });
 }
 
 // Retrieve array containing title, modified slug and 3 example pieces of

--- a/app/presenters/taxon-presenter.js
+++ b/app/presenters/taxon-presenter.js
@@ -27,7 +27,7 @@ function TaxonPresenter (request, defaultView) {
   // and consider whether or not to move them down into the specific templates
   // they're used by.
   this.curatedContent = this.contentListToRender.slice(0,6);
-  this.latestContent  = this.contentListToRender.slice(0,3);
+  this.latestContent  = this.contentListToRender.slice(-3).reverse();
 
   this.resolveViewTemplateName = function () {
     return request.path.replace(this.taxonSlug, '').replace(/^\//, 'design-') + this.selectedView;

--- a/app/routes.js
+++ b/app/routes.js
@@ -19,8 +19,8 @@ router.get('/mvp/:taxonSlug', function (req, res) {
 
 router.get('/tabless/:taxonSlug', function (req, res) {
   var presenter = new TaxonPresenter(req, 'base');
-  presenter.curatedContent = presenter.allContent.slice(-4);
-  presenter.latestContent = presenter.allContent.slice(0,3);
+  presenter.curatedContent = presenter.allContent.slice(4);
+  presenter.latestContent = presenter.allContent.slice(-3).reverse();
   res.render(presenter.viewTemplateName, presenter);
 });
 

--- a/bin/generate_prototype_data.rb
+++ b/bin/generate_prototype_data.rb
@@ -106,11 +106,7 @@ class GeneratePrototypeData
   end
 
   def hostname
-    if ENV["DEV"]
-      "http://content-store.dev.gov.uk"
-    else
-      "https://www.gov.uk"
-    end
+    "https://www.gov.uk"
   end
 end
 


### PR DESCRIPTION
Use the public_updated_at to apply a basic chronological order to
tagged content. Content items were previously rendered in the frontend
in whatever order they appear in the taxonomy-data.json. This allows
things like a view of the 'latest' content items to make at least some
kind of sense when viewed by the user.
