### PR TITLE
Display all content on pages for final-tier taxons

### DIFF
--- a/app/views/design-tabless/base.html
+++ b/app/views/design-tabless/base.html
@@ -84,6 +84,11 @@
     </form>
   </div>
 
+  {% if not childTaxons %}
+    {% for item in allContent %}
+      <p><a href="{{item.web_url}}">{{ item.title }}</a></p>
+    {% endfor %}
+  {% endif %}
 
   {% include "shared/_child-taxons.html" %}
 


### PR DESCRIPTION
For any taxon that is at the lowest level in its hierarchy, display a
list of all content tagged to this level. This commit will be followed
by further design work to style this list.

![screen shot 2016-06-14 at 11 49 25](https://cloud.githubusercontent.com/assets/519250/16040195/163a524a-3226-11e6-958c-ff7a438da874.png)
