### PR TITLE
Rename link type: alpha_taxons to taxons

### DIFF
--- a/bin/generate_prototype_data.rb
+++ b/bin/generate_prototype_data.rb
@@ -23,8 +23,8 @@ class GeneratePrototypeData
       children_documents = JSON.parse(Net::HTTP.get children_endpoint)["parent"]
 
       puts "Getting tagged content items..."
-      content_endpoint = URI "#{hostname}/api/incoming-links/alpha-taxonomy/#{taxon_slug}?types[]=alpha_taxons"
-      content_items    = JSON.parse(Net::HTTP.get content_endpoint)["alpha_taxons"]
+      content_endpoint = URI "#{hostname}/api/incoming-links/alpha-taxonomy/#{taxon_slug}?types[]=taxons"
+      content_items    = JSON.parse(Net::HTTP.get content_endpoint)["taxons"]
 
       puts "Getting format and display_type for each content item..."
       content_items.each do |content_item|


### PR DESCRIPTION
When we started experimenting with new taxonomy we used alpha_taxonomy
as the link type.
Now that we're no longer in alpha we'd like to be consistent in using
the link type.

Trello:
https://trello.com/c/tt0UdAV3/35-use-taxons-as-link-type-everywhere
2349d27
