### PR TITLE
Rename link type: alpha_taxons to taxons

### DIFF
--- a/bin/generate_prototype_data.rb
+++ b/bin/generate_prototype_data.rb
@@ -74,8 +74,8 @@ class GeneratePrototypeData
   end
 
   def content_items_tagged_to(taxon_slug)
-    content_endpoint = URI "#{hostname}/api/incoming-links/alpha-taxonomy/#{taxon_slug}?types[]=alpha_taxons"
-    JSON.parse(Net::HTTP.get content_endpoint)["alpha_taxons"]
+    content_endpoint = URI "#{hostname}/api/incoming-links/alpha-taxonomy/#{taxon_slug}?types[]=taxons"
+    JSON.parse(Net::HTTP.get content_endpoint)["taxons"]
   end
 
   def add_timestamps_to(content_item)


### PR DESCRIPTION
When we started experimenting with new taxonomy we used alpha_taxonomy
as the link type.
Now that we're no longer in alpha we'd like to be consistent in using
the link type.

Trello:
https://trello.com/c/tt0UdAV3/35-use-taxons-as-link-type-everywhere
2349d27
