### PR TITLE
Update README, retiring app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Navigation Prototype
 
-This app serves up prototype navigation flows for the work-in-progress GOV.UK
+**~~ THIS APPLICATION IS NOW RETIRED ~~**
+
+It has been replaced by [`govuk-nav-prototype`](https://github.com/alphagov/govuk-nav-prototype),
+which is a prototype rewritten in Rails.
+
+This app used to serve up prototype navigation flows for the work-in-progress GOV.UK
 taxonomy.
 
 ## Screenshots


### PR DESCRIPTION
This application has been superceded by a Ruby rewrite:
`govuk-nav-prototype`. This change updates the README to reflect that
in preparation for moving to the Attic.